### PR TITLE
Add dedicated HTML whitelist for admin accessibility audits

### DIFF
--- a/accessible-wp-toolkit/includes/helpers.php
+++ b/accessible-wp-toolkit/includes/helpers.php
@@ -1,6 +1,31 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
+function awpt_allowed_html() : array {
+    $allowed = wp_kses_allowed_html( 'post' );
+
+    foreach ( $allowed as &$attributes ) {
+        if ( ! is_array( $attributes ) ) {
+            continue;
+        }
+
+        $attributes['role']     = true;
+        $attributes['tabindex'] = true;
+        $attributes['aria-*']   = true;
+    }
+    unset( $attributes );
+
+    $allowed['track'] = array(
+        'default' => true,
+        'kind'    => true,
+        'label'   => true,
+        'srclang' => true,
+        'src'     => true,
+    );
+
+    return $allowed;
+}
+
 function awpt_capability() : string {
     return 'manage_options';
 }
@@ -53,19 +78,22 @@ function awpt_admin_state() : array {
             break;
 
         case 'keyboard':
-            $html = isset( $_POST['keyboard_html'] ) ? wp_kses_post( wp_unslash( $_POST['keyboard_html'] ) ) : '';
+            $html = isset( $_POST['keyboard_html'] ) ? wp_unslash( $_POST['keyboard_html'] ) : '';
+            $html = wp_kses( $html, awpt_allowed_html() );
             $state['inputs']['keyboard'] = array( 'html' => $html );
             $state['results']['keyboard'] = AWPT_Accessibility_API::keyboard_audit( $html );
             break;
 
         case 'landmarks':
-            $html = isset( $_POST['landmarks_html'] ) ? wp_kses_post( wp_unslash( $_POST['landmarks_html'] ) ) : '';
+            $html = isset( $_POST['landmarks_html'] ) ? wp_unslash( $_POST['landmarks_html'] ) : '';
+            $html = wp_kses( $html, awpt_allowed_html() );
             $state['inputs']['landmarks'] = array( 'html' => $html );
             $state['results']['landmarks'] = AWPT_Accessibility_API::analyze_landmarks( $html );
             break;
 
         case 'media':
-            $html = isset( $_POST['media_html'] ) ? wp_kses_post( wp_unslash( $_POST['media_html'] ) ) : '';
+            $html = isset( $_POST['media_html'] ) ? wp_unslash( $_POST['media_html'] ) : '';
+            $html = wp_kses( $html, awpt_allowed_html() );
             $state['inputs']['media'] = array( 'html' => $html );
             $state['results']['media'] = AWPT_Accessibility_API::analyze_media_alternatives( $html );
             break;

--- a/accessible-wp-toolkit/readme.txt
+++ b/accessible-wp-toolkit/readme.txt
@@ -24,6 +24,18 @@ Chaque module fonctionne sans recharger la page complète de WordPress et propos
 1. Copier le dossier `accessible-wp-toolkit` dans `wp-content/plugins/`.
 2. Activer le plugin depuis l’admin WordPress.
 
+== Tests ==
+=== Test manuel : Attributs ARIA conservés ===
+1. Ouvrir l’outil correspondant dans l’administration WordPress (Audit clavier, Repères ARIA ou Sous-titres & médias).
+2. Coller l’extrait suivant dans le champ HTML :
+```
+<button tabindex="5">Action prioritaire</button>
+<video controls>
+    <track kind="captions" src="demo.vtt" srclang="fr" label="Français" />
+</video>
+```
+3. Valider l’outil et vérifier que les avertissements concernant le `tabindex="5"` et la présence de la piste `<track kind="captions">` sont bien listés.
+
 == Changelog ==
 = 0.2.0 =
 * Implémentation des 4 outils (contraste, audit clavier, repères, médias)


### PR DESCRIPTION
## Summary
- introduce awpt_allowed_html() to preserve ARIA-, role, and tabindex attributes while sanitizing admin submissions
- reuse the dedicated whitelist when sending HTML to the accessibility API tools
- document a manual regression test covering tabindex and track caption handling

## Testing
- php -l accessible-wp-toolkit/includes/helpers.php

------
https://chatgpt.com/codex/tasks/task_e_68e632ed8cec8326adc8db8f7e1436f4