### PR TITLE
Replace panel placeholders with accessible controls

### DIFF
--- a/faciliti-side-panel/assets/css/panel.css
+++ b/faciliti-side-panel/assets/css/panel.css
@@ -76,18 +76,14 @@
   display: grid;
 }
 .fsp-section{
-  border: 1px dashed #ddd;
+  border: 1px solid #e1e1e1;
   border-radius: var(--fsp-radius);
-  padding: 12px;
+  padding: 16px;
   background: #fafafa;
 }
 .fsp-section h3{
-  margin: 0 0 8px 0;
+  margin: 0 0 12px 0;
   font-size: 1rem;
-}
-.fsp-placeholder{
-  color: #7a7a7a;
-  font-style: italic;
 }
 .fsp-panel__footer{
   position: sticky;
@@ -106,15 +102,196 @@
   background: #f5f5f5;
   padding: 8px 12px;
   cursor: pointer;
+  font-weight: 600;
+  transition: background .2s ease, color .2s ease, border-color .2s ease;
 }
 .fsp-btn.primary{
   background:#1b6ef3;
   color:#fff;
   border-color:#1b6ef3;
 }
+.fsp-btn.secondary{
+  background:#fff;
+  color:#1b1b1b;
+}
+.fsp-btn:hover{
+  background:#e9e9e9;
+}
+.fsp-btn.primary:hover{
+  background:#0f59d0;
+  border-color:#0f59d0;
+}
+.fsp-btn.primary:focus-visible{
+  background:#0f59d0;
+  border-color:#0f59d0;
+}
+.fsp-btn.secondary:hover{
+  background:#f0f0f0;
+}
+.fsp-form{
+  display: grid;
+  gap: 12px;
+}
+.fsp-label{
+  font-weight: 600;
+}
+.fsp-form__controls{
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.fsp-input{
+  flex: 1 1 180px;
+  border-radius: 8px;
+  border: 1px solid #c9c9c9;
+  padding: 10px 12px;
+  font-size: 1rem;
+}
+.fsp-input::placeholder{
+  color:#6c6c6c;
+}
+.fsp-toggle-list{
+  display: grid;
+  gap: 8px;
+  padding: 0;
+  margin: 0;
+}
+.fsp-toggle-list li{
+  list-style: none;
+}
+.fsp-toggle{
+  width: 100%;
+  border-radius: 999px;
+  border: 2px solid #c9c9c9;
+  padding: 10px 16px;
+  background: #fff;
+  color: #222;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background .2s ease, color .2s ease, border-color .2s ease;
+}
+.fsp-toggle.is-active{
+  background: #1b6ef3;
+  border-color: #1b6ef3;
+  color: #fff;
+}
+.fsp-toggle:hover{
+  background:#f0f4ff;
+}
+.fsp-toggle.is-active:hover{
+  background:#0f59d0;
+  border-color:#0f59d0;
+}
+.fsp-select{
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid #c9c9c9;
+  padding: 10px 12px;
+  font-size: 1rem;
+  background: #fff;
+  color: #1c1c1c;
+}
+.fsp-settings-list{
+  display: grid;
+  gap: 12px;
+  padding: 0;
+  margin: 0;
+}
+.fsp-setting{
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 12px;
+  border-radius: 12px;
+  background: #fff;
+  border: 1px solid #e1e1e1;
+}
+.fsp-setting__content{
+  flex: 1;
+  display: grid;
+  gap: 4px;
+}
+.fsp-setting__label{
+  font-weight: 600;
+}
+.fsp-setting__description{
+  font-size: .875rem;
+  color:#4b4b4b;
+}
+.fsp-switch{
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+.fsp-switch input{
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+.fsp-switch__indicator{
+  position: relative;
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #c9c9c9;
+  transition: background .2s ease;
+}
+.fsp-switch__indicator::after{
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform .2s ease;
+  box-shadow: 0 1px 3px rgba(0,0,0,.2);
+}
+.fsp-switch input:checked + .fsp-switch__indicator{
+  background: #1b6ef3;
+}
+.fsp-switch input:checked + .fsp-switch__indicator::after{
+  transform: translateX(20px);
+}
+.fsp-switch__text{
+  font-size: .875rem;
+  font-weight: 600;
+}
+.fsp-panel button,
+.fsp-panel input,
+.fsp-panel select{
+  font-family: inherit;
+}
+.fsp-panel button:disabled{
+  cursor: not-allowed;
+  opacity: .6;
+}
+.fsp-btn:focus-visible,
+.fsp-toggle:focus-visible,
+.fsp-select:focus-visible,
+.fsp-input:focus-visible,
+.fsp-switch input:focus-visible + .fsp-switch__indicator{
+  outline: 3px solid #1b6ef3;
+  outline-offset: 2px;
+}
 @media (prefers-color-scheme: dark){
   .fsp-panel{ background:#18181b; color:#ececec; }
   .fsp-panel__header, .fsp-panel__footer{ border-color:#2a2a2a; background:#18181b;}
   .fsp-section{ background:#111113; border-color:#2a2a2a; }
   .fsp-launcher{ box-shadow:none; }
+  .fsp-btn{ background:#2a2a2a; border-color:#343434; color:#e5e5e5; }
+  .fsp-btn.primary{ background:#3b82f6; border-color:#3b82f6; }
+  .fsp-btn.secondary{ background:#1f1f23; }
+  .fsp-toggle{ background:#1f1f23; border-color:#343434; color:#ececec; }
+  .fsp-toggle.is-active{ background:#3b82f6; border-color:#3b82f6; }
+  .fsp-setting{ background:#1f1f23; border-color:#343434; }
+  .fsp-setting__description{ color:#c4c4c4; }
+  .fsp-select, .fsp-input{ background:#1f1f23; border-color:#343434; color:#ececec; }
+  .fsp-switch__indicator{ background:#3f3f46; }
+  .fsp-switch input:checked + .fsp-switch__indicator{ background:#3b82f6; }
 }

--- a/faciliti-side-panel/assets/js/panel.js
+++ b/faciliti-side-panel/assets/js/panel.js
@@ -1,6 +1,22 @@
 (function() {
-  const q = (sel, ctx=document) => ctx.querySelector(sel);
-  const qa = (sel, ctx=document) => Array.from(ctx.querySelectorAll(sel));
+  const q = (sel, ctx = document) => ctx.querySelector(sel);
+  const qa = (sel, ctx = document) => Array.from(ctx.querySelectorAll(sel));
+  const STORAGE_KEY = 'fsp-panel-state';
+
+  const defaultState = {
+    search: '',
+    quickFilters: {
+      dyslexia: false,
+      'eye-strain': false,
+      night: false
+    },
+    category: '',
+    settings: {
+      contrast: false,
+      font: false,
+      motion: false
+    }
+  };
 
   function trapFocus(container) {
     const focusableSelectors = [
@@ -23,6 +39,161 @@
     }
   }
 
+  function storageAvailable(){
+    try {
+      const test = '__fsp__';
+      localStorage.setItem(test, test);
+      localStorage.removeItem(test);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+
+  const HAS_STORAGE = storageAvailable();
+
+  function loadState(){
+    if (!HAS_STORAGE) return JSON.parse(JSON.stringify(defaultState));
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (!stored) return JSON.parse(JSON.stringify(defaultState));
+      const parsed = JSON.parse(stored);
+      return {
+        ...JSON.parse(JSON.stringify(defaultState)),
+        ...parsed,
+        quickFilters: { ...defaultState.quickFilters, ...(parsed.quickFilters || {}) },
+        settings: { ...defaultState.settings, ...(parsed.settings || {}) }
+      };
+    } catch (err) {
+      return JSON.parse(JSON.stringify(defaultState));
+    }
+  }
+
+  function saveState(state){
+    if (!HAS_STORAGE) return;
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (err) {
+      // ignore
+    }
+  }
+
+  function clearState(){
+    if (!HAS_STORAGE) return;
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch (err) {
+      // ignore
+    }
+  }
+
+  function setupControls(panel){
+    const searchForm = q('[data-fsp-search]', panel);
+    const searchInput = searchForm ? q('input[type="search"]', searchForm) : null;
+    const quickToggles = qa('[data-fsp-toggle]', panel);
+    const categorySelect = q('[data-fsp-category]', panel);
+    const settingInputs = qa('[data-fsp-setting]', panel);
+    const resetBtn = q('[data-fsp-reset]', panel);
+    const applyBtn = q('[data-fsp-apply]', panel);
+
+    let state = loadState();
+
+    function syncQuickButtons(){
+      quickToggles.forEach(btn => {
+        const key = btn.getAttribute('data-fsp-toggle');
+        const active = !!state.quickFilters[key];
+        btn.setAttribute('aria-pressed', String(active));
+        btn.classList.toggle('is-active', active);
+      });
+    }
+
+    function syncSettings(){
+      settingInputs.forEach(input => {
+        const key = input.getAttribute('data-fsp-setting');
+        input.checked = !!state.settings[key];
+      });
+    }
+
+    function syncSearch(){
+      if (searchInput) searchInput.value = state.search || '';
+    }
+
+    function syncCategory(){
+      if (categorySelect) categorySelect.value = state.category || '';
+    }
+
+    function syncAll(){
+      syncQuickButtons();
+      syncSettings();
+      syncSearch();
+      syncCategory();
+    }
+
+    function dispatchApply(){
+      const detail = JSON.parse(JSON.stringify(state));
+      panel.dispatchEvent(new CustomEvent('fsp:apply', { detail }));
+    }
+
+    syncAll();
+
+    quickToggles.forEach(btn => {
+      btn.addEventListener('click', () => {
+        const key = btn.getAttribute('data-fsp-toggle');
+        state.quickFilters[key] = !state.quickFilters[key];
+        saveState(state);
+        syncQuickButtons();
+      });
+    });
+
+    settingInputs.forEach(input => {
+      input.addEventListener('change', () => {
+        const key = input.getAttribute('data-fsp-setting');
+        state.settings[key] = input.checked;
+        saveState(state);
+      });
+    });
+
+    if (categorySelect){
+      categorySelect.addEventListener('change', () => {
+        state.category = categorySelect.value;
+        saveState(state);
+      });
+    }
+
+    if (searchForm && searchInput){
+      searchForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        state.search = searchInput.value.trim();
+        saveState(state);
+        dispatchApply();
+      });
+      searchInput.addEventListener('input', () => {
+        state.search = searchInput.value;
+        saveState(state);
+      });
+    }
+
+    if (resetBtn){
+      resetBtn.addEventListener('click', () => {
+        state = JSON.parse(JSON.stringify(defaultState));
+        clearState();
+        syncAll();
+        panel.dispatchEvent(new CustomEvent('fsp:reset'));
+      });
+    }
+
+    if (applyBtn){
+      applyBtn.addEventListener('click', () => {
+        dispatchApply();
+      });
+    }
+
+    return {
+      getState: () => JSON.parse(JSON.stringify(state)),
+      apply: dispatchApply
+    };
+  }
+
   function setup(){
     const launcher = q('.fsp-launcher');
     const overlay = q('.fsp-overlay');
@@ -39,7 +210,6 @@
       overlay.setAttribute('aria-hidden','false');
       launcher.setAttribute('aria-expanded','true');
       tf.enable();
-      // Focus the first focusable or the close button
       const firstFocusable = panel.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
       (firstFocusable || closeBtn).focus();
       document.body.style.overflow = 'hidden';
@@ -52,6 +222,8 @@
       document.body.style.overflow = '';
       if (prevFocused) prevFocused.focus();
     }
+
+    setupControls(panel);
 
     launcher.addEventListener('click', open);
     closeBtn.addEventListener('click', close);

--- a/faciliti-side-panel/templates/panel.php
+++ b/faciliti-side-panel/templates/panel.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Basic slide-in panel markup with placeholders only.
+ * Basic slide-in panel markup with accessible controls.
  * Customize freely. Keep IDs/classes to benefit from default JS/CSS.
  */
 ?>
@@ -12,38 +12,91 @@
 
 <aside id="fsp-panel" class="fsp-panel" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="fsp-panel-title">
   <header class="fsp-panel__header">
-    <h2 id="fsp-panel-title" class="fsp-title">Accessibilité — Placeholder</h2>
+    <h2 id="fsp-panel-title" class="fsp-title">Accessibilité</h2>
     <button class="fsp-close" aria-label="<?php esc_attr_e('Close panel','faciliti-side-panel'); ?>">✕</button>
   </header>
 
   <div class="fsp-panel__body">
     <section class="fsp-section" aria-labelledby="fsp-search-title">
-      <h3 id="fsp-search-title">Recherche (placeholder)</h3>
-      <div class="fsp-placeholder">[ champ de recherche à implémenter ]</div>
+      <h3 id="fsp-search-title">Recherche</h3>
+      <form class="fsp-form" role="search" data-fsp-search>
+        <label class="fsp-label" for="fsp-search-input">Rechercher un mot clé</label>
+        <div class="fsp-form__controls">
+          <input id="fsp-search-input" class="fsp-input" type="search" name="s" placeholder="Rechercher" autocomplete="off" />
+          <button type="submit" class="fsp-btn secondary">Rechercher</button>
+        </div>
+      </form>
     </section>
 
     <section class="fsp-section" aria-labelledby="fsp-quick-title">
-      <h3 id="fsp-quick-title">Filtres rapides (placeholder)</h3>
-      <ul class="fsp-placeholder" role="list">
-        <li>• Dyslexie — (switch à ajouter)</li>
-        <li>• Fatigue visuelle — (switch à ajouter)</li>
-        <li>• Mode nuit — (switch à ajouter)</li>
+      <h3 id="fsp-quick-title">Filtres rapides</h3>
+      <ul class="fsp-toggle-list" role="list" data-fsp-quick-toggle-group>
+        <li>
+          <button type="button" class="fsp-toggle" data-fsp-toggle="dyslexia" aria-pressed="false">Mode dyslexie</button>
+        </li>
+        <li>
+          <button type="button" class="fsp-toggle" data-fsp-toggle="eye-strain" aria-pressed="false">Réduire la fatigue visuelle</button>
+        </li>
+        <li>
+          <button type="button" class="fsp-toggle" data-fsp-toggle="night" aria-pressed="false">Mode nuit</button>
+        </li>
       </ul>
     </section>
 
     <section class="fsp-section" aria-labelledby="fsp-categories-title">
-      <h3 id="fsp-categories-title">Catégories (placeholder)</h3>
-      <div class="fsp-placeholder">[ sélecteur de catégorie, options dynamiques à venir ]</div>
+      <h3 id="fsp-categories-title">Catégories</h3>
+      <label class="fsp-label" for="fsp-category-select">Choisir une catégorie</label>
+      <select id="fsp-category-select" class="fsp-select" data-fsp-category>
+        <option value="">Toutes les catégories</option>
+        <option value="vision">Vision</option>
+        <option value="audition">Audition</option>
+        <option value="mobilite">Mobilité</option>
+        <option value="cognition">Cognition</option>
+      </select>
     </section>
 
     <section class="fsp-section" aria-labelledby="fsp-toggles-title">
-      <h3 id="fsp-toggles-title">Réglages (placeholder)</h3>
-      <div class="fsp-placeholder">[ liste de réglages avec interrupteurs, sliders, etc. ]</div>
+      <h3 id="fsp-toggles-title">Réglages</h3>
+      <ul class="fsp-settings-list" role="list">
+        <li class="fsp-setting">
+          <div class="fsp-setting__content">
+            <span class="fsp-setting__label">Augmenter le contraste</span>
+            <span class="fsp-setting__description">Renforce les contrastes pour un meilleur confort de lecture.</span>
+          </div>
+          <label class="fsp-switch">
+            <input type="checkbox" data-fsp-setting="contrast" />
+            <span class="fsp-switch__indicator" aria-hidden="true"></span>
+            <span class="fsp-switch__text">Activer</span>
+          </label>
+        </li>
+        <li class="fsp-setting">
+          <div class="fsp-setting__content">
+            <span class="fsp-setting__label">Augmenter la taille du texte</span>
+            <span class="fsp-setting__description">Agrandit la typographie du contenu principal.</span>
+          </div>
+          <label class="fsp-switch">
+            <input type="checkbox" data-fsp-setting="font" />
+            <span class="fsp-switch__indicator" aria-hidden="true"></span>
+            <span class="fsp-switch__text">Activer</span>
+          </label>
+        </li>
+        <li class="fsp-setting">
+          <div class="fsp-setting__content">
+            <span class="fsp-setting__label">Réduire les animations</span>
+            <span class="fsp-setting__description">Limite les effets visuels et transitions rapides.</span>
+          </div>
+          <label class="fsp-switch">
+            <input type="checkbox" data-fsp-setting="motion" />
+            <span class="fsp-switch__indicator" aria-hidden="true"></span>
+            <span class="fsp-switch__text">Activer</span>
+          </label>
+        </li>
+      </ul>
     </section>
   </div>
 
   <div class="fsp-panel__footer">
-    <button class="fsp-btn">Réinitialiser (placeholder)</button>
-    <button class="fsp-btn primary">Appliquer (placeholder)</button>
+    <button type="button" class="fsp-btn" data-fsp-reset>Réinitialiser</button>
+    <button type="button" class="fsp-btn primary" data-fsp-apply>Appliquer</button>
   </div>
 </aside>


### PR DESCRIPTION
## Summary
- replace the panel placeholders with accessible search, filter, category, and settings controls
- synchronize control state in JavaScript, including persistence, ARIA updates, and apply/reset callbacks
- add styling for the interactive controls with clear focus indicators and dark-mode support

## Testing
- php -l faciliti-side-panel/templates/panel.php

------
https://chatgpt.com/codex/tasks/task_e_68e632f4e21c8326bc6b21d6afa21e34