### PR TITLE
Synchronize accessibility panel open label between PHP and JS

### DIFF
--- a/faciliti-side-panel/faciliti-side-panel.php
+++ b/faciliti-side-panel/faciliti-side-panel.php
@@ -14,15 +14,29 @@ define( 'FSP_VERSION', '0.1.0' );
 define( 'FSP_URL', plugin_dir_url( __FILE__ ) );
 define( 'FSP_PATH', plugin_dir_path( __FILE__ ) );
 
+if ( ! function_exists( 'fsp_get_open_label' ) ) {
+    /**
+     * Retrieve the translated open button label.
+     */
+    function fsp_get_open_label() {
+        $label = apply_filters( 'fsp/open_label', __( 'Open accessibility panel', 'faciliti-side-panel' ) );
+
+        return is_string( $label ) ? $label : '';
+    }
+}
+
 /**
  * Enqueue assets
  */
 add_action( 'wp_enqueue_scripts', function() {
+    $open_label  = fsp_get_open_label();
+    $close_label = __( 'Close panel', 'faciliti-side-panel' );
+
     wp_enqueue_style( 'fsp-panel', FSP_URL . 'assets/css/panel.css', [], FSP_VERSION );
     wp_enqueue_script( 'fsp-panel', FSP_URL . 'assets/js/panel.js', [], FSP_VERSION, true );
     wp_localize_script( 'fsp-panel', 'FSP', [
-        'openLabel'  => __( 'Open accessibility panel', 'faciliti-side-panel' ),
-        'closeLabel' => __( 'Close panel', 'faciliti-side-panel' ),
+        'openLabel'  => $open_label,
+        'closeLabel' => $close_label,
     ]);
 });
 
@@ -30,6 +44,8 @@ add_action( 'wp_enqueue_scripts', function() {
  * Render panel in footer by default
  */
 add_action( 'wp_footer', function() {
+    $fsp_open_label = fsp_get_open_label();
+
     include FSP_PATH . 'templates/panel.php';
 });
 
@@ -38,6 +54,8 @@ add_action( 'wp_footer', function() {
  */
 add_shortcode( 'faciliti_panel', function() {
     ob_start();
+    $fsp_open_label = fsp_get_open_label();
+
     include FSP_PATH . 'templates/panel.php';
     return ob_get_clean();
 });

--- a/faciliti-side-panel/templates/panel.php
+++ b/faciliti-side-panel/templates/panel.php
@@ -4,8 +4,15 @@
  * Customize freely. Keep IDs/classes to benefit from default JS/CSS.
  */
 ?>
+<?php
+$open_label = isset( $fsp_open_label ) ? $fsp_open_label : fsp_get_open_label();
+
+if ( '' === $open_label ) {
+    $open_label = esc_html__( 'Open accessibility panel', 'faciliti-side-panel' );
+}
+?>
 <button class="fsp-launcher" aria-expanded="false" aria-controls="fsp-panel">
-  <?php echo esc_html( isset( $fsp_open_label ) ? $fsp_open_label : ( isset( $GLOBALS['FSP']['openLabel'] ) ? $GLOBALS['FSP']['openLabel'] : 'Open panel' ) ); ?>
+  <?php echo esc_html( $open_label ); ?>
 </button>
 
 <div class="fsp-overlay" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- add a helper to centralize the translated "open panel" label and expose a filter for customization
- update the PHP template to consume the helper instead of relying on the global JS object
- share the filtered label with JavaScript via `wp_localize_script`

## Testing
- php -l faciliti-side-panel/faciliti-side-panel.php
- php -l faciliti-side-panel/templates/panel.php

------
https://chatgpt.com/codex/tasks/task_e_68e6330bdb04832692d1a66f270a8fc1